### PR TITLE
wrong method name used in database_helpers

### DIFF
--- a/datacache/database_helpers.py
+++ b/datacache/database_helpers.py
@@ -97,7 +97,7 @@ def _create_cached_db(
                 logging.info("Dropping tables from database %s: %s",
                     db_path,
                     ", ".join(db.table_names()))
-                db.drop_tables()
+                db.drop_all_tables()
             logging.info(
                 "Creating database %s containing: %s",
                 db_path,


### PR DESCRIPTION
Should be `drop_all_tables()` but instead calling `drop_tables()`. 

Fixes https://github.com/hammerlab/pyensembl/issues/65

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/datacache/21)
<!-- Reviewable:end -->
