### PR TITLE
switched from progressbar to its Py3 compatible fork progressbar33

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas>=0.15.2
 appdirs>=1.4.0
-progressbar>=2.2
+progressbar33>=2.4
 biopython>=1.65
 requests>=2.5.1
 typechecks>=0.0.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         install_requires=[
             "pandas>=0.15.2",
             "appdirs>=1.4.0",
-            "progressbar>=2.2",
+            "progressbar33>=2.4",
             "biopython>=1.65",
             "requests>=2.5.1",
             "typechecks>=0.0.2",


### PR DESCRIPTION
Fixes https://github.com/hammerlab/datacache/issues/22 and https://github.com/hammerlab/pyensembl/issues/66. 

Someone kindly made a fork of `progressbar` which works with Python3. It's called `progressbar33` (source at https://github.com/germangh/python-progressbar)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/datacache/23)
<!-- Reviewable:end -->
