### PR TITLE
Allow datacache to use any DB-API backend

### DIFF
--- a/datacache/common.py
+++ b/datacache/common.py
@@ -15,15 +15,18 @@
 
 import hashlib
 from os import makedirs, environ
-from os.path import join, exists, split, splitext
+from os.path import join, exists, split, splitext, basename
 import re
+from sqlalchemy.engine.url import URL, make_url
 
 from shutil import rmtree
 import appdirs
 
+
 def ensure_dir(path):
     if not exists(path):
         makedirs(path)
+
 
 def get_data_dir(subdir=None, envkey=None):
     if envkey and envkey in environ:
@@ -32,14 +35,27 @@ def get_data_dir(subdir=None, envkey=None):
         subdir = "datacache"
     return appdirs.user_cache_dir(subdir)
 
+
+def build_sqlite_url(collection_name, subdir=None):
+    filename = "%s.db" % collection_name
+    path = build_path(filename, subdir)
+    return "%s%s" % ("sqlite:///", path)
+
+
 def build_path(filename, subdir=None):
     data_dir = get_data_dir(subdir)
     ensure_dir(data_dir)
     return join(data_dir, filename)
 
+
+def get_db_name(db_url):
+    return basename(make_url(db_url).database)
+
+
 def clear_cache(subdir=None):
     data_dir = get_data_dir(subdir)
     rmtree(data_dir)
+
 
 def normalize_filename(filename):
     """
@@ -53,6 +69,7 @@ def normalize_filename(filename):
         filename = prefix + filename[-140:]
 
     return filename
+
 
 def build_local_filename(download_url=None, filename=None, decompress=False):
     """

--- a/datacache/database.py
+++ b/datacache/database.py
@@ -13,80 +13,106 @@
 # limitations under the License.
 
 import logging
-import sqlite3
+from sqlalchemy import create_engine
+from sqlalchemy.schema import MetaData
+from sqlalchemy.exc import OperationalError
 
-from typechecks import require_integer, require_string, require_iterable_of
+from typechecks import (require_integer, require_string,
+                        require_iterable_of)
 
-METADATA_TABLE_NAME = "_datacache_metadata"
+METADATA_TABLE_PREFIX = "_datacache_metadata"
 
 class Database(object):
     """
-    Wrapper object for sqlite3 database which provides helpers for
+    Wrapper object for a database which provides helpers for
     querying and constructing the datacache metadata table, as well as
     creating and checking for existence of particular table names.
 
-    Calls to methods other than Database.close() and Database.create()
-    will not commit their changes.
-    """
-    def __init__(self, path):
-        self.path = path
-        self.connection = sqlite3.connect(path)
+    This "Database" represents a collection that may share a physical
+    database with other collections.
 
-    def _commit(self):
-        self.connection.commit()
+    Calls to methods will not commit their changes, other than:
+     * Database.create
+     * Database.drop_tables
+     * Database.drop_collection_tables
+    """
+    def __init__(self, db_url, collection_name):
+        self.engine = create_engine(db_url)
+        # Do not autocommit by default
+        self.connection = self.engine.connect().execution_options(
+            autocommit=False)
+        # Bind to the connection rather than the engine
+        # so that it reflects the state of this transaction
+        self.metadata = MetaData(bind=self.connection, reflect=False)
+        self.collection_name = collection_name
+
+    def update_metadata(self):
+        """Updates SQLAlchemy metadata (table information)"""
+        # Note: this metadata object is totally separate from
+        # DataCache's concept of a metadata table.
+        self.metadata.reflect()
 
     def close(self):
-        """Commit changes and close database connection"""
-        self._commit()
+        """Close database connection"""
         self.connection.close()
 
     def table_names(self):
-        """Returns names of all tables in the database"""
-        query = "SELECT name FROM sqlite_master WHERE type='table'"
-        cursor = self.connection.execute(query)
-        results = cursor.fetchall()
-        return [result_tuple[0] for result_tuple in results]
+        """Returns names of all tables in the collection"""
+        self.update_metadata()
+        table_names = self.metadata.tables.keys()
+        return [table_name for table_name in table_names if
+                table_name.endswith(self.collection_name)]
 
     def has_table(self, table_name):
-        """Does a table named `table_name` exist in the sqlite database?"""
+        """Does a table named `table_name` exist in the collection?"""
         table_names = self.table_names()
         return table_name in table_names
 
-    def drop_all_tables(self):
-        """Drop all tables in the database"""
-        for table_name in self.table_names():
-            self.execute_sql("DROP TABLE %s" % table_name)
-        self.connection.commit()
+    def drop_tables(self, table_names):
+        """Drop all tables in the argument list"""
+        # The context manager commits at the close of the transaction
+        with self.connection.begin():
+            logging.info("Dropping tables from database: %s",
+                         ", ".join(table_names))
+            for table_name in table_names:
+                try:
+                    self.execute_sql("DROP TABLE \"%s\"" % table_name)
+                except OperationalError as e:
+                    logging.warn("Encountered error %s while trying to "
+                                 "drop table \"%s\"" %
+                                 (e.message, table_name))
 
     def execute_sql(self, sql, commit=False):
         """Log and then execute a SQL query"""
-        logging.info("Running sqlite query: \"%s\"", sql)
-        self.connection.execute(sql)
-        if commit:
-            self.connection.commit()
+        logging.info("Running database query: \"%s\"", sql)
+        self.connection.execution_options(
+            autocommit=commit).execute(sql)
 
     def has_tables(self, table_names):
         """Are all of the given table names present in the database?"""
         return all(self.has_table(table_name) for table_name in table_names)
 
     def has_version(self):
-        """Does this database have version information?
+        """Does this database have version information for this collection?
 
-        The absence of version information indicates that this database was
+        The absence of version information indicates that this collection was
         either not created by datacache or is incomplete.
         """
-        return self.has_table(METADATA_TABLE_NAME)
+        return self.has_table(self.metadata_table_name())
 
     def version(self):
-        """What's the version of this database? Found in metadata attached
-        by datacache when creating this database."""
-        query = "SELECT version FROM %s" % METADATA_TABLE_NAME
+        """What's the version of this collection? Found in metadata attached
+        by datacache when creating this collection."""
+        query = "SELECT version FROM \"%s\"" % self.metadata_table_name()
         cursor = self.connection.execute(query)
         version = cursor.fetchone()
         if not version:
             return 0
         else:
             return int(version[0])
+
+    def metadata_table_name(self):
+        return "%s_%s" % (METADATA_TABLE_PREFIX, self.collection_name)
 
     def _finalize_database(self, version):
         """
@@ -99,20 +125,21 @@ class Database(object):
         """
         require_integer(version, "version")
         create_metadata_sql = \
-            "CREATE TABLE %s (version INT)" % METADATA_TABLE_NAME
+            "CREATE TABLE \"%s\" (version INT)" % self.metadata_table_name()
         self.execute_sql(create_metadata_sql)
         insert_version_sql = \
-            "INSERT INTO %s VALUES (%s)" % (METADATA_TABLE_NAME, version)
+            "INSERT INTO \"%s\" VALUES (%s)" % (self.metadata_table_name(), version)
         self.execute_sql(insert_version_sql)
 
     def _create_table(self, table_name, column_types, primary=None, nullable=()):
-        """Creates a sqlite3 table from the given metadata.
+        """Creates a database table from the given metadata.
 
         Parameters
         ----------
 
         column_types : list of (str, str) pairs
-            First element of each tuple is the column name, second element is the sqlite3 type
+            First element of each tuple is the column name, 
+            second element is the database column type
 
         primary : str, optional
             Which column is the primary key
@@ -121,14 +148,14 @@ class Database(object):
             Names of columns which have null values
         """
         require_string(table_name, "table name")
-        require_iterable_of(column_types, tuple, name="rows")
+        require_iterable_of(column_types, tuple, name="column_types")
         if primary is not None:
             require_string(primary, "primary")
         require_iterable_of(nullable, str, name="nullable")
 
         column_decls = []
         for column_name, column_type in column_types:
-            decl = "%s %s" % (column_name, column_type)
+            decl = "\"%s\" %s" % (column_name, column_type)
             if column_name == primary:
                 decl += " UNIQUE PRIMARY KEY"
             if column_name not in nullable:
@@ -136,16 +163,16 @@ class Database(object):
             column_decls.append(decl)
         column_decl_str = ", ".join(column_decls)
         create_table_sql = \
-            "CREATE TABLE %s (%s)" % (table_name, column_decl_str)
+            "CREATE TABLE \"%s\" (%s)" % (table_name, column_decl_str)
         self.execute_sql(create_table_sql)
 
     def _fill_table(self, table_name, rows):
         require_string(table_name, "table_name")
-        require_iterable_of(rows, tuple, "rows")
+        require_iterable_of(rows, dict, "rows")
 
         if not self.has_table(table_name):
             raise ValueError(
-                "Table '%s' does not exist in database" % (table_name,))
+                "Table \"%s\" does not exist in database" % (table_name,))
         if len(rows) == 0:
             raise ValueError("Rows must be non-empty sequence")
 
@@ -153,13 +180,15 @@ class Database(object):
         n_columns = len(first_row)
         if not all(len(row) == n_columns for row in rows):
             raise ValueError("Rows must all have %d values" % n_columns)
-        blank_slots = ", ".join("?" for _ in range(n_columns))
         logging.info("Inserting %d rows into table %s", len(rows), table_name)
-        sql = "INSERT INTO %s VALUES (%s)" % (table_name, blank_slots)
-        self.connection.executemany(sql, rows)
 
-    def create(self, tables, version):
-        """Do the actual work of creating the database, filling its tables with
+        # Note that sqlalchemy uses "execute" as a wrapper around
+        # DB-API's "executemany"
+        self.connection.execute(self.metadata.tables[table_name].insert(),
+                                rows)
+
+    def create(self, tables, overwrite, version):
+        """Do the actual work of creating the collection, filling its tables with
         values, creating indices, and setting the datacache version metadata.
 
         Parameters
@@ -167,18 +196,27 @@ class Database(object):
         tables : list
             List of datacache.DatabaseTable objects
 
+        overwrite : bool
+            Overwrite existing tables?
+
         version : int
         """
-        for table in tables:
-            self._create_table(
-                table_name=table.name,
-                column_types=table.column_types,
-                primary=table.primary_key,
-                nullable=table.nullable)
-            self._fill_table(table.name, table.rows)
-            self._create_indices(table.name, table.indices)
-        self._finalize_database(version)
-        self._commit()
+        # The context manager commits at the close of the transaction
+        with self.connection.begin() as trans:
+            # If we're overwriting, get rid of any tables we're
+            # about to create (including the metadata table).
+            if overwrite:
+                self.drop_tables([table.name for table in tables] +
+                                 [self.metadata_table_name()])
+            for table in tables:
+                self._create_table(
+                    table_name=table.name,
+                    column_types=table.column_types,
+                    primary=table.primary_key,
+                    nullable=table.nullable)
+                self._fill_table(table.name, table.rows)
+                self._create_indices(table.name, table.indices)
+            self._finalize_database(version)
 
     def _create_index(self, table_name, index_columns):
         """
@@ -198,11 +236,12 @@ class Database(object):
         index_name = "%s_index_%s" % (
             table_name,
             "_".join(index_columns))
+
         self.connection.execute(
-            "CREATE INDEX IF NOT EXISTS %s ON %s (%s)" % (
-                index_name,
-                table_name,
-                ", ".join(index_columns)))
+            "CREATE INDEX %s ON %s (%s)" % (
+                "\"%s\"" % index_name,
+                "\"%s\"" % table_name,
+                ", ".join(["\"%s\"" % col for col in index_columns])))
 
     def _create_indices(self, table_name, indices):
         """

--- a/datacache/database_table.py
+++ b/datacache/database_table.py
@@ -15,7 +15,7 @@
 from .database_types import db_type
 
 class DatabaseTable(object):
-    """Converts between a DataFrame and a sqlite3 database table"""
+    """Converts between a DataFrame and a database table"""
 
     def __init__(
             self,
@@ -55,7 +55,7 @@ class DatabaseTable(object):
             column_types.append((column_name.replace(" ", "_"), column_db_type))
 
         def make_rows():
-            return list(tuple(row) for row in df.values)
+            return df.to_dict(orient="records")
 
         return cls(
             name=name,
@@ -76,7 +76,7 @@ class DatabaseTable(object):
 
         def make_rows():
             return [
-                (idx, str(record.seq))
+                {key_column: idx, value_column: str(record.seq)}
                 for (idx, record)
                 in fasta_dict.items()
             ]

--- a/datacache/database_types.py
+++ b/datacache/database_types.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Convert from Python type names to sqlite3 column types"""
+"""Convert from Python type names to database column types"""
 
 import numpy as np
 
+# Note: these types won't work with any arbitary DB-API backend,
+# though they do work with SQLite and Postgres.
 _dtype_to_db_type_dict = {
  'int': 'INT',
  'int8': 'INT',
@@ -85,11 +87,11 @@ def db_type(python_type_representation):
         (1) Python type
         (2) NumPy/Pandas dtypes
         (3) string names of types
-    ...to a sqlite3 type name
+    ...to a database type name
     """
     for type_name in _candidate_type_names(python_type_representation):
         db_type_name = _lookup_type_name(type_name)
         if db_type_name:
             return db_type_name
-    raise ValueError("Failed to find sqlite3 column type for %s" % (
+    raise ValueError("Failed to find database column type for %s" % (
         python_type_representation))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ biopython>=1.65
 requests>=2.5.1
 typechecks>=0.0.0
 nose>=1.3.3
+sqlalchemy>=1.0.4
+sqlalchemy_utils>=0.30.6

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ except:
 if __name__ == "__main__":
     setup(
         name="datacache",
-        version="0.4.14",
+        version="0.5.0",
         description="Helpers for transparently downloading datasets",
         author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",
@@ -61,6 +61,8 @@ if __name__ == "__main__":
             "biopython>=1.65",
             "requests>=2.5.1",
             "typechecks>=0.0.2",
+            "sqlalchemy>=1.0.4",
+            "sqlalchemy_utils>=0.30.6"
         ],
         long_description=readme,
         packages=["datacache"],

--- a/test/test_db_from_dataframes.py
+++ b/test/test_db_from_dataframes.py
@@ -2,34 +2,39 @@ from nose.tools import eq_
 import pandas as pd
 from tempfile import NamedTemporaryFile
 from datacache import db_from_dataframes, db_from_dataframe
+from datacache.database_helpers import build_table_name
+
+from .util import get_collection_name
 
 dfA = pd.DataFrame({"numbers": [1, 2, 3], "strings": ["a", "b", "c"]})
 dfB = pd.DataFrame({"wuzzles": ["nuzzle", "ruzzle"]})
 
 def test_database_from_dataframes():
     with NamedTemporaryFile(suffix="test.db") as f:
+        collection_name = get_collection_name(f)
         db = db_from_dataframes(
-            db_filename=f.name,
+            collection_name=collection_name,
             dataframes={"A": dfA, "B": dfB},
             primary_keys={"A": "numbers"},
             indices={"A": [("numbers", "strings")]},
             subdir="test_datacache")
-        cursor_A = db.execute("SELECT * FROM A")
+        cursor_A = db.execute("SELECT * FROM \"%s\"" % build_table_name("A", collection_name))
         results_A = cursor_A.fetchall()
         eq_(results_A, [(1, "a"), (2, "b"), (3, "c")])
-        cursor_B = db.execute("SELECT * FROM B")
+        cursor_B = db.execute("SELECT * FROM \"%s\"" % build_table_name("B", collection_name))
         results_B = cursor_B.fetchall()
         eq_(results_B, [("nuzzle",), ("ruzzle",)])
 
 def test_database_from_single_dataframe():
     with NamedTemporaryFile(suffix="test.db") as f:
+        collection_name = get_collection_name(f)
         db = db_from_dataframe(
-            db_filename=f.name,
+            collection_name=collection_name,
             table_name="A",
             df=dfA,
             primary_key="numbers",
             indices=[("numbers", "strings")],
             subdir="test_datacache")
-        cursor = db.execute("SELECT * FROM A")
+        cursor = db.execute("SELECT * FROM \"%s\"" % build_table_name("A", collection_name))
         results = cursor.fetchall()
         eq_(results, [(1, "a"), (2, "b"), (3, "c")])

--- a/test/test_fasta_db.py
+++ b/test/test_fasta_db.py
@@ -19,5 +19,5 @@ URL = \
     'ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.75.dna_rm.chromosome.MT.fa.gz'
 
 def test_download_fasta_db():
-    db = fetch_fasta_db("DNA", URL)
+    db = fetch_fasta_db("DNA", URL, overwrite=True)
     assert db is not None

--- a/test/util.py
+++ b/test/util.py
@@ -1,0 +1,5 @@
+from os.path import splitext, basename
+
+def get_collection_name(db_file):
+    file_name = db_file.name
+    return splitext(basename(file_name))[0]


### PR DESCRIPTION
cc @arahuja 

This PR:

* Adds the notion of a "collection", where the "Homo_sapiens.GRCh37.75" collection results in tables "exon_Homo_sapiens.GRCh37.75", "gene_Homo_sapiens.GRCh37.75", etc.
* Adds a `db_url` argument in a number of places, in place of a file path. This gets read by `sqlalchemy` per http://docs.sqlalchemy.org/en/latest/core/engines.html
* Collections can be placed in separate DBs, which is the default if no `db_url` is provided; or, they can co-exist together in any DB. The table names are the same for either option.

`datacache` handles most of the logic, though the `pyensembl` changes are intimately related: https://github.com/hammerlab/pyensembl/pull/91

TODO before merge:

* More testing.

Not in this PR:

* Postgres data insertion can be dramatically sped up using `COPY` instead of individual inserts.
* In addition to Ensembl GTF files, pyensembl loads in FASTA files for direct sequence access. Those are indexed by http://biopython.org/DIST/docs/api/Bio.SeqIO-module.html#index_db into their own SQLite databases, which are currently still SQLite databases.
* Moving away from raw SQL to `sqlalchemy`'s layer of abstraction.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/datacache/25)
<!-- Reviewable:end -->
